### PR TITLE
HTTPアクセスを許可する記述を削除

### DIFF
--- a/src/app/Http/Middleware/ForceHttps.php
+++ b/src/app/Http/Middleware/ForceHttps.php
@@ -17,7 +17,7 @@ class ForceHttps
     public function handle(Request $request, Closure $next)
     {
         // httpによるアクセスをhttpsにリダイレクトする
-        if (\App::environment(['production']) && isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER["HTTP_X_FORWARDED_PROTO"] != 'https')
+        if (\App::environment(['production']) && $_SERVER["HTTP_X_FORWARDED_PROTO"] != 'https')
         {
             return redirect()->secure($request->getRequestUri());
         }


### PR DESCRIPTION
[b662944](https://github.com/yuyamh/datemaki-practice/pull/3/commits/b662944872c6f63369c35360f7d6e254079aff6d)
- 上記の記述追加で、タイムアウトエラーが発生するため、上記前回のコミットでの追加分を削除した。