### PR TITLE
[fix]CloudFront導入により、添付ファイル取得にサブドメイン割り当て

### DIFF
--- a/src/config/filesystems.php
+++ b/src/config/filesystems.php
@@ -50,7 +50,7 @@ return [
             'secret' => env('AWS_SECRET_ACCESS_KEY'),
             'region' => env('AWS_DEFAULT_REGION'),
             'bucket' => env('AWS_BUCKET'),
-            'url' => env('AWS_URL'),
+            'url' => 'https://file.datemaki-practice.xyz',
             'endpoint' => env('AWS_ENDPOINT'),
             'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
             'throw' => false,


### PR DESCRIPTION
### 変更点
- CloudFrontの導入により、添付ファイル・画像の取得をS3のURLではなく、サブドメイン（file.datemaki-practice.xyz）の方に切り替えた。
- ディスクから呼び出されるURLもサブドメインに切り替えるよう、filesystems.phpに変更を加えた。