### PR TITLE
update: API用教案データの新規保存&更新処理の追加

### DIFF
--- a/src/app/Http/Controllers/Api/PostController.php
+++ b/src/app/Http/Controllers/Api/PostController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\PostFormRequest;
 use App\Models\Post;
 use Illuminate\Http\Request;
 
@@ -19,14 +20,42 @@ class PostController extends Controller
 
 
     /**
-     * Store a newly created resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * 教案の新規保存
      */
-    public function store(Request $request)
+    public function store(PostFormRequest $request)
     {
-        //
+        $validated = $request->validated();
+
+        $post = new Post();
+        $post->title = $validated['title'];
+        $post->description = $validated['description'];
+        $post->level = $validated['level'];
+        $post->user_id = \Auth::id();
+        $post->text_id = $validated['text_id'];
+
+        if (isset($validated['file_name']))
+        {
+            $file = $validated['file_name'];
+            $ext  = $file->getClientOriginalextension();
+
+            // ファイルをストレージへ保存
+            $fileName = time() . '.' . $ext;
+            $file->storeAs('public/files', $fileName);
+
+            $post->file_name = $fileName;
+            $post->file_mimetype = $file->getMimeType();
+            $post->file_size = $file->getSize();
+        }
+
+        $post->save();
+
+        // return redirect(route('myposts.index'))->with('successMessage', '教案を投稿しました。');
+        return response()->json(
+            [
+                'message' => '教案を投稿しました。',
+                'post' => $post,
+            ], 200
+        );
     }
 
     /**

--- a/src/app/Http/Controllers/Web/Auth/AuthenticatedSessionController.php
+++ b/src/app/Http/Controllers/Web/Auth/AuthenticatedSessionController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Web\Auth;
 
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Auth\LoginRequest;
+use App\Http\Requests\Web\Auth\LoginRequest;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;

--- a/src/app/Http/Controllers/Web/PostController.php
+++ b/src/app/Http/Controllers/Web/PostController.php
@@ -3,10 +3,10 @@
 namespace App\Http\Controllers\Web;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Web\StorePostRequest;
 use App\Models\Post;
 use App\Models\Text;
 use Illuminate\Http\Request;
-use App\Http\Requests\StorePostRequest;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\DB;
 

--- a/src/app/Http/Controllers/Web/ProfileController.php
+++ b/src/app/Http/Controllers/Web/ProfileController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Web;
 
 use App\Http\Controllers\Controller;
-use App\Http\Requests\ProfileUpdateRequest;
+use App\Http\Requests\Web\ProfileUpdateRequest;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;

--- a/src/app/Http/Requests/Api/PostFormRequest.php
+++ b/src/app/Http/Requests/Api/PostFormRequest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Validation\Rule;
+
+class PostFormRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        $rules = [
+            'title' => 'required|max:255',
+            'description' => 'required',
+            'level' => ['required', Rule::in(['A1', 'A2', 'B1', 'B2', 'C1', 'C2'])],
+            'file_name' => [
+                'file',
+                // 拡張子
+                'mimes:pdf,docx,zip,xlsx,jpeg,jpg,png',
+                // MIMEタイプ：Word, Excel, Zip, PDF
+                'mimetypes:application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/zip,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,image/jpeg,image/png',
+            ],
+            'text_id' => 'nullable|exists:texts,id',
+        ];
+
+        return $rules;
+    }
+
+    // API用のエラーレスポンスを返す
+    protected function failedValidation(Validator $validator)
+    {
+        $res = response()->json([
+            'errors' => $validator->errors(),
+            ],
+            400);
+            
+        throw new HttpResponseException($res);
+    }
+}

--- a/src/app/Http/Requests/Web/Auth/LoginRequest.php
+++ b/src/app/Http/Requests/Web/Auth/LoginRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Requests\Auth;
+namespace App\Http\Requests\Web\Auth;
 
 use Illuminate\Auth\Events\Lockout;
 use Illuminate\Foundation\Http\FormRequest;

--- a/src/app/Http/Requests/Web/ProfileUpdateRequest.php
+++ b/src/app/Http/Requests/Web/ProfileUpdateRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Requests;
+namespace App\Http\Requests\Web;
 
 use App\Models\User;
 use Illuminate\Foundation\Http\FormRequest;

--- a/src/app/Http/Requests/Web/StorePostRequest.php
+++ b/src/app/Http/Requests/Web/StorePostRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Requests;
+namespace App\Http\Requests\Web;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;


### PR DESCRIPTION
### 変更点
- API用のFormRequestクラスの作成に伴い、ディレクトリ構成を下記のように変更した。
    - src/app/Http/Requests以下に、新たにWeb, Apiディレクトリを追加。
    - src/app/Http/Requests以下にある、既存ファイルをsrc/app/Http/Requests/Web以下へ移動した。
    - 上記のファイル移動に合わせ、各コントローラファイルの名前空間を修正した。
    - src/app/Http/Requests/Api以下に、新たにJSONでレスポンスを返すAPI用のFormRequestクラスを作成した。
- APIでの教案データの新規保存を行う処理を追加。
- APIでの特定の教案データを更新する処理を追加。
- src/routes/api.phpに、ルーティングをリソースルートとして設定。
- PostmanでのAPIテスト実施済。