### PR TITLE
update: 投稿の一覧取得＆詳細取得処理の変更

### DIFF
--- a/src/app/Http/Controllers/Api/PostController.php
+++ b/src/app/Http/Controllers/Api/PostController.php
@@ -112,7 +112,30 @@ class PostController extends Controller
             }
         }
 
-        return response()->json($post, 200);
+        $data = [
+            "result" => [
+                "id" => $post->id,
+                "title" => $post->title,
+                "descripion" => $post->description,
+                "user" => [
+                    "id" => $post->user_id,
+                    "name" => $post->user->name,
+                ],
+                "file" => [
+                    "file_name" => $post->file_name ?? null,
+                    "file_mimetype" => $post->file_mimetype ?? null,
+                    "file_size" => $post->file_size ?? null,
+                ],
+                "text" => [
+                    "id" => $post->text_id ?? null,
+                    "name" => $post->text->text_name ?? null,
+                ],
+                "created_at" => $post->created_at,
+                "updated_at" => $post->created_at,
+            ]
+        ];
+
+        return response()->json($data, 200);
     }
 
     /**

--- a/src/app/Http/Controllers/Api/PostController.php
+++ b/src/app/Http/Controllers/Api/PostController.php
@@ -14,7 +14,34 @@ class PostController extends Controller
      */
     public function index()
     {
-        $posts = Post::latest()->get();
+        $posts = Post::select('id', 'title', 'description', 'level', 'user_id','text_id', 'updated_at')
+            ->latest('updated_at')
+            ->with(['user', 'text'])
+            ->get();
+
+        // ユーザー名、テキスト名を含む新しいコレクションを作成
+        $posts = $posts->map(function ($post) {
+            $data = [
+                'id' => $post->id,
+                'title' => $post->title,
+                'description' => $post->description,
+                'level' => $post->level,
+                'user_name' => $post->user->name,
+                'updated_at' => $post->updated_at,
+            ];
+
+            // テキストがnullの場合
+            if ($post->text)
+            {
+                $data['text_name'] = $post->text->text_name;
+            } else
+            {
+                $data['text_name'] = 'なし';
+            }
+
+            return $data;
+        });
+
         return response()->json($posts, 200);
     }
 


### PR DESCRIPTION
### 変更点
- 一覧取得及び詳細取得処理のレスポンス内容を変更。
- APIの使用を想定して、レスポンスをより具体的なキー・値へ変更した。
- Postmanで動作確認済。