### PR TITLE
update: API処理におけるJSONレスポンスの共通化

### DIFF
--- a/src/app/Http/Controllers/Api/BaseController.php
+++ b/src/app/Http/Controllers/Api/BaseController.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Traits\ResponseJson;
+use Illuminate\Http\Request;
+
+class BaseController extends Controller
+{
+    use ResponseJson;
+}

--- a/src/app/Http/Controllers/Api/BookmarkController.php
+++ b/src/app/Http/Controllers/Api/BookmarkController.php
@@ -2,10 +2,9 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Http\Controllers\Controller;
 use App\Models\Bookmark;
 
-class BookmarkController extends Controller
+class BookmarkController extends BaseController
 {
 
     /**
@@ -20,6 +19,7 @@ class BookmarkController extends Controller
         } else
         {
             // すでにブックマーク済みの場合
+            // TODO:エラーレスポンス共通化
             return response()->json(
                 [
                     'status' => 'false',
@@ -30,12 +30,9 @@ class BookmarkController extends Controller
             );
         }
 
-        return response()->json(
-            [
-                'status' => 'true',
-                'result' => 'OK',
-            ], 200
-        );
+        $this->setResponseData(['status' => true]);
+
+        return $this->responseSuccess();
     }
 
     /**
@@ -50,6 +47,7 @@ class BookmarkController extends Controller
         } else
         {
             // すでにブックマーク解除済みの場合
+            // TODO:エラーレスポンス共通化
             return response()->json(
                 [
                     'status' => 'false',
@@ -60,11 +58,8 @@ class BookmarkController extends Controller
             );
         }
 
-        return response()->json(
-            [
-                'status' => 'true',
-                'result' => 'OK',
-            ], 200
-        );
+        $this->setResponseData(['status' => true]);
+
+        return $this->responseSuccess();
     }
 }

--- a/src/app/Http/Controllers/Api/ProfileController.php
+++ b/src/app/Http/Controllers/Api/ProfileController.php
@@ -65,31 +65,9 @@ class ProfileController extends BaseController
 
         $request->user()->save();
 
-        if ($request->user()->profile_image)
-        {
-            $data = [
-                "id" => $request->user()->id,
-                "name" => $request->user()->name,
-                "email" => $request->user()->email,
-                "profile_image" => $request->user()->image_url,
-            ];
-        } else
-        {
-            $data = [
-                "id" => $request->user()->id,
-                "name" => $request->user()->name,
-                "email" => $request->user()->email,
-                "profile_image" => asset('images/user_icon.png')
-            ];
-        }
+        // TODO: エラーレスポンス導入時にRequestからのエラー返却考える
+        $this->setResponseData(['status' => true]);
 
-        return response()->json(
-            [
-                'status' => 'true',
-                'result' => [
-                    'user' => $data,
-                ],
-            ], 200
-        );
+        return $this->responseSuccess();
     }
 }

--- a/src/app/Http/Controllers/Api/ProfileController.php
+++ b/src/app/Http/Controllers/Api/ProfileController.php
@@ -2,11 +2,10 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\ApiProfileUpdateRequest;
 use Illuminate\Http\Request;
 
-class ProfileController extends Controller
+class ProfileController extends BaseController
 {
 
     /**
@@ -16,26 +15,21 @@ class ProfileController extends Controller
     {
         $user = \Auth::user();
 
-        $user = [
-            "id" => $user->id,
-            "name" => $user->name,
-            "email" => $user->email,
+        $response = [
+            "id"                => $user->id,
+            "name"              => $user->name,
+            "email"             => $user->email,
             "email_verified_at" => $user->email_verified_at,
-            "role" => $user->role,
-            "profile_image" => $user->profile_image,
-            "image_url" => $user->profile_image ? $user->image_url : null,
-            "created_at" => $user->created_at,
-            "updated_at" => $user->updated_at,
+            "role"              => $user->role,
+            "profile_image"     => $user->profile_image,
+            "image_url"         => $user->profile_image ? $user->image_url : asset('images/user_icon.png'),
+            "created_at"        => $user->created_at,
+            "updated_at"        => $user->updated_at,
         ];
 
-        return response()->json(
-            [
-                'status' => 'true',
-                'result' => [
-                    'user' => $user,
-                ],
-            ], 200
-        );
+        $this->setResponseData($response);
+
+        return $this->responseSuccess(false);
     }
 
     /**

--- a/src/app/Http/Controllers/Api/TextController.php
+++ b/src/app/Http/Controllers/Api/TextController.php
@@ -2,11 +2,10 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Http\Controllers\Controller;
 use App\Models\Text;
 use Illuminate\Http\Request;
 
-class TextController extends Controller
+class TextController extends BaseController
 {
     /**
      * テキストの一覧取得
@@ -15,11 +14,18 @@ class TextController extends Controller
     {
         $texts = Text::all();
 
-        return response()->json(
-            [
-                'status' => 'true',
-                'result' => $texts,
-            ], 200
-        );
+        $response = [];
+        foreach ($texts as $text)
+        {
+            $tmp = [
+                'id'   => $text->id,
+                'name' => $text->text_name,
+            ];
+            array_push($response, $tmp);
+        }
+
+        $this->setResponseData($response);
+
+        return $this->responseSuccess(false);
     }
 }

--- a/src/app/Http/Controllers/Api/UserController.php
+++ b/src/app/Http/Controllers/Api/UserController.php
@@ -2,11 +2,10 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\Request;
 
-class UserController extends Controller
+class UserController extends BaseController
 {
     /**
      * ユーザー一覧取得
@@ -28,37 +27,21 @@ class UserController extends Controller
 
         $users = $query->get();
 
-        // 送信するユーザー情報のコレクションを編成
-        $users = $users->map(function ($user) {
+        $response = [];
+        foreach ($users as $user)
+        {
+            $tmp = [
+                'id'            => $user->id,
+                'user_name'     => $user->name,
+                'profile_image' => $user->profile_image ? $user->image_url : asset('images/user_icon.png'),
+                'posts_counts'  => count($user->posts)
+            ];
+            array_push($response, $tmp);
+        }
 
-            // // プロフィール画像未設定の場合は、デフォルト画像をセットする。
-            if ($user->profile_image)
-            {
-                $data = [
-                    "id" => $user->id,
-                    "name" => $user->name,
-                    "profile_image" => $user->image_url,
-                    "posts_counts" => count($user->posts)
-                ];
-            } else
-            {
-                $data = [
-                    "id" => $user->id,
-                    "name" => $user->name,
-                    "profile_image" => asset('images/user_icon.png'),
-                    "posts_counts" => count($user->posts)
-                ];
-            }
+        $this->setResponseData($response);
 
-            return $data;
-        });
-
-        return response()->json(
-            [
-                'status' => 'true',
-                'result' => $users,
-            ], 200
-        );
+        return $this->responseSuccess(false);
     }
 
     /**

--- a/src/app/Traits/ResponseJson.php
+++ b/src/app/Traits/ResponseJson.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Traits;
+
+trait ResponseJson
+{
+
+    /**
+     * レスポンスステータスコード
+     *
+     * @var int
+     */
+    protected $statusCode = 200;
+
+    /**
+     * レスポンスステータス
+     *
+     * @var bool
+     */
+    protected $status = true;
+
+    /**
+     * レスポンスデータ
+     *
+     * @var bool
+     */
+    protected $data = [];
+
+    /**
+     * レスポンスヘッダ
+     *
+     * @var array
+     */
+    protected $responseHeader = [];
+
+    /**
+     * レスポンスデータをセット
+     *
+     * @param Array data
+     * @return void
+     */
+    protected function setResponseData($data = [])
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * レスポンスヘッダをセット
+     *
+     * @param Array responseHeader
+     * @return void
+     */
+    protected function setResponseHeader($responseHeader)
+    {
+        $this->responseHeader = $responseHeader;
+    }
+
+    /**
+     * レスポンス成功
+     *
+     * @return Array json
+     */
+    protected function responseSuccess($isObject = true)
+    {
+        $this->status = true;
+
+        return $this->responseJson($isObject);
+    }
+
+    /**
+     * 共通のJSONレスポンス内容を作成
+     *
+     * @return Array json
+     */
+    private function responseJson($isObject = true)
+    {
+        if ($isObject) {
+            $data = !empty($this->data) ? $this->data : (object)[];
+        } else {
+            $data = !empty($this->data) ? $this->data : [];
+        }
+
+        $response = [
+            'data' => $data,
+            // 'error_messages' => $this->errorMessages
+        ];
+
+        return response()->json($response, $this->statusCode)
+        ->withHeaders($this->responseHeader);
+    }
+}


### PR DESCRIPTION
### 変更点
- 各API処理において、返却されるJSONデータをコントローラに依存させず処理を切り出して共通化を図った。
    - レスポンスの内容を整形するトレイトを新たに追加し、コントローラ内で宣言。
    - 各コントローラのメソッドにて、レスポンスの整形を上記トレイトの処理に委託し返却されるJSONデータを統一化。
- 今回の変更では下記のレスポンス内容を統一化させた。 
    - 使用テキスト情報
    - 会員登録済みユーザ情報
    - プロフィール情報
    - ブックマーク情報（一覧取得・登録・解除）
- エラーレスポンスについては別途共通化処理を記述予定。 