### PR TITLE
update: API処理におけるJSONレスポンスの共通化（投稿処理＆認証処理）

### DIFF
--- a/src/app/Http/Controllers/Api/AuthenticateController.php
+++ b/src/app/Http/Controllers/Api/AuthenticateController.php
@@ -3,11 +3,10 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Requests\Api\AuthenticateRequest;
-use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
-class AuthenticateController extends Controller
+class AuthenticateController extends BaseController
 {
 
     /**
@@ -20,9 +19,11 @@ class AuthenticateController extends Controller
         if (Auth::attempt($credentials))
         {
             $token = Auth::user()->createToken('AccessToken')->plainTextToken;
-            return response()->json(['token' => $token], 200);
+            $this->setResponseData(['token' => $token]);
+            return $this->responseSuccess();
         } else
         {
+            // TODO:エラーレスポンス
             return response()->json(['error' => '認証に失敗しました。'], 401);
         }
     }
@@ -33,6 +34,8 @@ class AuthenticateController extends Controller
     public function logout(Request $request)
     {
         $request->user()->currentAccessToken()->delete();
-        return response()->json(['message' => 'ログアウトしました。'], 200);
+        $this->setResponseData(['status' => 'true']);
+
+        return $this->responseSuccess();
     }
 }

--- a/src/app/Http/Controllers/Api/PostController.php
+++ b/src/app/Http/Controllers/Api/PostController.php
@@ -187,12 +187,10 @@ class PostController extends BaseController
         // アップロードされたファイルの削除
         \Storage::delete('public/files/' . $post->file_name);
 
-        return response()->json(
-            [
-                'status' => 'true',
-                'result' => "OK",
-            ], 200
-        );
+        // TODO:エラーレスポンス導入
+        $this->setResponseData(['status' => 'true']);
+
+        return $this->responseSuccess();
     }
 
     /**

--- a/src/app/Http/Controllers/Api/PostController.php
+++ b/src/app/Http/Controllers/Api/PostController.php
@@ -91,14 +91,9 @@ class PostController extends BaseController
             $post->file_size = PostService::convertBytesToMegaBytes($post->file_size);
         }
 
-        return response()->json(
-            [
-                'status' => 'true',
-                'result' => [
-                    'post' => $post,
-                ],
-            ], 200
-        );
+        $this->setResponseData(['status' => 'true']);
+
+        return $this->responseSuccess();
     }
 
     /**
@@ -177,14 +172,9 @@ class PostController extends BaseController
             $post->file_size = PostService::convertBytesToMegaBytes($post->file_size);
         }
 
-        return response()->json(
-            [
-                'status' => 'true',
-                'result' => [
-                    'post' => $post,
-                ],
-            ], 200
-        );
+        $this->setResponseData(['status' => 'true']);
+
+        return $this->responseSuccess();
     }
 
     /**

--- a/src/app/Http/Controllers/Api/PostController.php
+++ b/src/app/Http/Controllers/Api/PostController.php
@@ -15,39 +15,43 @@ class PostController extends BaseController
     public function index()
     {
         $posts = Post::select('id', 'title', 'description', 'level', 'user_id','text_id', 'updated_at')
-            ->latest('updated_at')
             ->with(['user', 'text'])
+            ->latest('updated_at')
             ->get();
 
-        // ユーザー名、テキスト名を含む新しいコレクションを作成
-        $posts = $posts->map(function ($post) {
-            $data = [
-                "id" => $post->id,
-                "title" => $post->title,
-                "description" => $post->description,
-                "level" => $post->level,
-                "user" => [
-                    "id" => $post->user_id,
-                    "name" => $post->user->name,
+        $response = [];
+        foreach ($posts as $post)
+        {
+            $text = null;
+            if ($post->text_id)
+            {
+                $text = [
+                    'id'   => $post->text_id,
+                    'name' => $post->text->text_name,
+                ];
+            }
+            $tmp = [
+                'id'          => $post->id,
+                'title'       => $post->title,
+                'description' => $post->description,
+                'level'       => $post->level,
+                'user'        => [
+                    'id'            => $post->user_id,
+                    'name'          => $post->user->name,
+                    'profile_image' => $post->user->profile_image ? $post->user->image_url : asset('images/user_icon.png'),
+
                 ],
-                "text" => [
-                    "id" => $post->text_id ?? null,
-                    "name" => $post->text->text_name ?? null,
-                ],
-                "updated_at" => $post->updated_at,
+                'text'        => $text,
+                'updated_at'  => $post->updated_at,
             ];
+            array_push($response, $tmp);
+        }
 
-            return $data;
-        });
+        // TODO:paginationのセット
 
-        return response()->json(
-            [
-                'status' => 'true',
-                'result' => [
-                    'posts' => $posts,
-                ],
-            ], 200
-        );
+        $this->setResponseData($response);
+
+        return $this->responseSuccess(false);
     }
 
 
@@ -107,36 +111,32 @@ class PostController extends BaseController
             $post->file_size = PostService::convertBytesToMegaBytes($post->file_size);
         }
 
-        $post = [
-            "id" => $post->id,
-            "title" => $post->title,
-            "description" => $post->description,
-            "user" => [
-                "id" => $post->user_id,
-                "name" => $post->user->name,
+        $response = [
+            'id'          => $post->id,
+            'title'       => $post->title,
+            'description' => $post->description,
+            'level'       => $post->level,
+            'user'        => [
+                'id'   => $post->user_id,
+                'name' => $post->user->name,
             ],
-            "file" => [
-                "file_name" => $post->file_name ?? null,
-                "file_mimetype" => $post->file_mimetype ?? null,
-                "file_size" => $post->file_size ?? null,
-                "file_url" => $post->file_name ? $post->file_url : null, // ファイル添付がない場合は、URLをNULLで返す
+            'file' => [
+                'file_name'     => $post->file_name ?? null,
+                'file_mimetype' => $post->file_mimetype ?? null,
+                'file_size'     => $post->file_size ?? null,
+                'file_url'      => $post->file_name ? $post->file_url : null,
             ],
-            "text" => [
-                "id" => $post->text_id ?? null,
-                "name" => $post->text->text_name ?? null,
+            'text' => [
+                'id'   => $post->text_id ?? null,
+                'name' => $post->text->text_name ?? null,
             ],
-            "created_at" => $post->created_at,
-            "updated_at" => $post->created_at,
+            'created_at'  => $post->created_at,
+            'updated_at'  => $post->created_at,
         ];
 
-        return response()->json(
-            [
-                'status' => 'true',
-                'result' => [
-                    'post' => $post,
-                ],
-            ], 200
-        );
+        $this->setResponseData($response);
+
+        return $this->responseSuccess();
     }
 
     /**


### PR DESCRIPTION
### 変更点
- 各API処理において、返却されるJSONデータをコントローラに依存させず処理を切り出して共通化を図った。
- 今回の変更では下記のレスポンス内容を統一化させた。
    - 投稿に関する処理関連
    - アクセストークンでの認証処理関連