### PR TITLE
update: API処理のエラーレスポンスにおけるJSONレスポンスの共通化

### DIFF
--- a/src/app/Http/Controllers/Api/AuthenticateController.php
+++ b/src/app/Http/Controllers/Api/AuthenticateController.php
@@ -23,8 +23,9 @@ class AuthenticateController extends BaseController
             return $this->responseSuccess();
         } else
         {
-            // TODO:エラーレスポンス
-            return response()->json(['error' => '認証に失敗しました。'], 401);
+            $this->setStatusCode(401);
+            $this->setErrorMessages(['メールアドレスまたはパスワードが間違っています']);
+            return $this->responseFailed();
         }
     }
 

--- a/src/app/Http/Controllers/Api/BookmarkController.php
+++ b/src/app/Http/Controllers/Api/BookmarkController.php
@@ -19,15 +19,10 @@ class BookmarkController extends BaseController
         } else
         {
             // すでにブックマーク済みの場合
-            // TODO:エラーレスポンス共通化
-            return response()->json(
-                [
-                    'status' => 'false',
-                    'result' => [
-                        'message' => 'すでにブックマーク済みです。',
-                    ]
-                ], 409
-            );
+            $this->setStatusCode(400);
+            $this->setErrorMessages(['すでにブックマーク済みです。']);
+            $this->setResponseData(['status' => false]);
+            return $this->responseFailed();
         }
 
         $this->setResponseData(['status' => true]);
@@ -47,15 +42,10 @@ class BookmarkController extends BaseController
         } else
         {
             // すでにブックマーク解除済みの場合
-            // TODO:エラーレスポンス共通化
-            return response()->json(
-                [
-                    'status' => 'false',
-                    'result' => [
-                        'message' => 'すでにブックマーク解除済みです。',
-                    ]
-                ], 409
-            );
+            $this->setStatusCode(400);
+            $this->setErrorMessages(['すでにブックマーク解除済みです。']);
+            $this->setResponseData(['status' => false]);
+            return $this->responseFailed();
         }
 
         $this->setResponseData(['status' => true]);

--- a/src/app/Http/Controllers/Api/ProfileController.php
+++ b/src/app/Http/Controllers/Api/ProfileController.php
@@ -65,7 +65,6 @@ class ProfileController extends BaseController
 
         $request->user()->save();
 
-        // TODO: エラーレスポンス導入時にRequestからのエラー返却考える
         $this->setResponseData(['status' => true]);
 
         return $this->responseSuccess();

--- a/src/app/Http/Requests/Api/ApiProfileUpdateRequest.php
+++ b/src/app/Http/Requests/Api/ApiProfileUpdateRequest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Validation\Rule;
 
-class ApiProfileUpdateRequest extends FormRequest
+class ApiProfileUpdateRequest extends BaseFormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -33,14 +33,4 @@ class ApiProfileUpdateRequest extends FormRequest
             'image' => ['file', 'mimes:gif,png,jpg,webp', 'max:51200'],
         ];
     }
-
-    protected function failedValidation(Validator $validator)
-    {
-        $res = response()->json([
-            'errors' => $validator->errors(),
-            ], 400);
-        throw new HttpResponseException($res);
-    }
-
-
 }

--- a/src/app/Http/Requests/Api/AuthenticateRequest.php
+++ b/src/app/Http/Requests/Api/AuthenticateRequest.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
 
-class AuthenticateRequest extends FormRequest
+class AuthenticateRequest extends BaseFormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -29,13 +29,5 @@ class AuthenticateRequest extends FormRequest
             'email' => 'required | email',
             'password' => 'required'
         ];
-    }
-
-    protected function failedValidation(Validator $validator)
-    {
-        $res = response()->json([
-            'errors' => $validator->errors(),
-            ], 400);
-        throw new HttpResponseException($res);
     }
 }

--- a/src/app/Http/Requests/Api/BaseFormRequest.php
+++ b/src/app/Http/Requests/Api/BaseFormRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use App\Traits\ResponseJson;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class BaseFormRequest extends FormRequest
+{
+    use ResponseJson;
+
+    protected $validateErrors = [];
+
+    /**
+     * バリデーション失敗時エラーハンドリング
+     *
+     * @param Validator $validator
+     * @throws HttpResponseException
+     * @see FormRequest::failedValidation()
+     */
+    protected function failedValidation(Validator $validator)
+    {
+        $this->setStatusCode(400);
+        foreach ($validator->errors()->toArray() as $errors)
+        {
+            if (isset($errors[0]))
+            {
+                array_push($this->validateErrors, $errors[0]);
+            }
+        }
+        $this->setErrorMessages($this->validateErrors);
+
+        throw new HttpResponseException($this->responseFailed());
+    }
+}

--- a/src/app/Http/Requests/Api/PostFormRequest.php
+++ b/src/app/Http/Requests/Api/PostFormRequest.php
@@ -7,7 +7,7 @@ use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Validation\Rule;
 
-class PostFormRequest extends FormRequest
+class PostFormRequest extends BaseFormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -41,16 +41,5 @@ class PostFormRequest extends FormRequest
         ];
 
         return $rules;
-    }
-
-    // API用のエラーレスポンスを返す
-    protected function failedValidation(Validator $validator)
-    {
-        $res = response()->json([
-            'errors' => $validator->errors(),
-            ],
-            400);
-            
-        throw new HttpResponseException($res);
     }
 }

--- a/src/app/Traits/ResponseJson.php
+++ b/src/app/Traits/ResponseJson.php
@@ -20,6 +20,13 @@ trait ResponseJson
     protected $status = true;
 
     /**
+     * エラーメッセージ
+     *
+     * @var bool
+     */
+    protected $errorMessages = [];
+
+    /**
      * レスポンスデータ
      *
      * @var bool
@@ -34,6 +41,17 @@ trait ResponseJson
     protected $responseHeader = [];
 
     /**
+     * ステータスコードをセット
+     *
+     * @param String $statusCode
+     * @return void
+     */
+    protected function setStatusCode($statusCode)
+    {
+        $this->statusCode = $statusCode;
+    }
+
+    /**
      * レスポンスデータをセット
      *
      * @param Array data
@@ -42,6 +60,17 @@ trait ResponseJson
     protected function setResponseData($data = [])
     {
         $this->data = $data;
+    }
+
+    /**
+     * エラーメッセージをセット
+     *
+     * @param Array $errorMessages
+     * @return void
+     */
+    protected function setErrorMessages($errorMessages)
+    {
+        $this->errorMessages = $errorMessages;
     }
 
     /**
@@ -68,11 +97,23 @@ trait ResponseJson
     }
 
     /**
+     * レスポンス失敗
+     *
+     * @return Array json
+     */
+    protected function responseFailed($isObject = true)
+    {
+        $this->status = false;
+
+        return $this->responseJson($isObject);
+    }
+
+    /**
      * 共通のJSONレスポンス内容を作成
      *
      * @return Array json
      */
-    private function responseJson($isObject = true)
+    protected function responseJson($isObject = true)
     {
         if ($isObject) {
             $data = !empty($this->data) ? $this->data : (object)[];
@@ -82,7 +123,7 @@ trait ResponseJson
 
         $response = [
             'data' => $data,
-            // 'error_messages' => $this->errorMessages
+            'error_messages' => $this->errorMessages
         ];
 
         return response()->json($response, $this->statusCode)


### PR DESCRIPTION
### 変更点
- 各API処理のエラーレスポンスにおいて、返却されるJSONデータをコントローラに依存させず処理を切り出して共通化を図った。
- レスポンスの内容を整形するトレイト（src/app/Traits/ResponseJson.php）内に新たにエラーレスポンスに関する整形処理を追加。
- バリデーション時、上記のトレイトを用いてJSONデータを返すメソッドを各FormRequestクラスから切り出して共通化。
- 各コントローラのメソッドにて、レスポンスの整形を上記に委託し、返却されるエラーメッセージを統一化。
- 今回の変更で下記のエラーレスポンスを統一化させた。
    - 投稿保存・更新処理
    - プロフィール情報更新処理
    - ブックマーク処理（登録・解除）
    - ログイン処理