### PR TITLE
update: 不要なプロフィール画像の削除用バッチ処理の作成

### DIFF
--- a/src/app/Console/Commands/DeleteUnnecessaryProfileIcons.php
+++ b/src/app/Console/Commands/DeleteUnnecessaryProfileIcons.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class DeleteUnnecessaryProfileIcons extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'command:deleteProfileIcons';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'DBに紐付いていない不要なプロフィール画像の削除';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        // storage(S3)/public/profile_icons以下に保存されているプロフィール画像の取得
+        $icons = Storage::files('public/profile_icons');
+        $iconsInStorage = array_map(function ($icon) {
+            $parts = explode('public/profile_icons/', $icon);
+            return end($parts);
+        }, $icons);
+
+        // usersテーブルに紐付いているプロフィール画像の名前を取得
+        $iconsInDatabase = User::pluck('profile_image')->toArray();
+
+        // 差分を抽出
+        $iconsToBeDeleted = array_diff($iconsInStorage, $iconsInDatabase);
+
+        foreach ($iconsToBeDeleted as $iconname)
+        {
+            Storage::delete('public/profile_icons/' . $iconname);
+        }
+    }
+}

--- a/src/app/Console/Kernel.php
+++ b/src/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Console\Commands\DeleteUnnecessaryProfileIcons;
 use app\Console\Commands\DeleteUnnecessaryUploadedFiles;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
@@ -15,6 +16,7 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
+        DeleteUnnecessaryProfileIcons::class,
         DeleteUnnecessaryUploadedFiles::class,
     ];
 
@@ -26,6 +28,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
+        $schedule->command('command:deleteProfileIcons')->daily();
         $schedule->command('command:deleteFiles')->daily();
     }
 


### PR DESCRIPTION
### 変更点
- アップロードされたがテーブルに紐づいていない、不要なプロフィール画像の削除を定期的に実行するバッチ処理を作成した。
- 具体的な追加項目は下記。
    - プロフィール画像削除用コマンドを新たに作成。
    - タスクスケジューラに上記コマンドを、毎日深夜12時に実行されるよう設定。